### PR TITLE
Cobaya interface

### DIFF
--- a/man/prepare_cobaya.man.sh
+++ b/man/prepare_cobaya.man.sh
@@ -1,0 +1,182 @@
+#
+# prepare_cosmosis.sh Documentation & Housekeeping functions
+#
+
+#Starting Prompt {{{
+function _prompt { 
+  #Check if we do want verbose output
+  if [ "$1" != "0" ] 
+  then
+    _message "@BLU@========================================@DEF@\n"
+    _message "@BLU@== @RED@ Running prepare_cobaya.sh Mode @BLU@ ==@DEF@\n"
+    _message "@BLU@========================================@DEF@\n"
+  fi 
+}
+#}}}
+
+#Mode description {{{
+function _description { 
+  echo "#"
+  echo '# Prepare cobaya configuration'
+  echo "#"
+  echo "# Function takes input data:"
+  echo "# `_inp_data`"
+  echo "#"
+}
+#}}}
+
+# Abort Message {{{
+_abort()
+{
+  #Message to print when script aborts 
+  #$0 is the script that was running when this error occurred
+  _message "@BLU@ An error occured while running:\n@DEF@$0.\n" >&2
+  _message "@BLU@ Check the logging file for this step in:\n" >&2
+  _message "@DEF@@RUNROOT@/@LOGPATH@/\n" >&2
+  exit 1
+}
+trap '_abort' 0
+set -e 
+#}}}
+
+# Input variables {{{ 
+function _inp_var { 
+  #Variable inputs (leave blank if none)
+  echo BLU BV:BOLTZMAN BV:PRIOR_ABARY BV:PRIOR_AIA BV:PRIOR_H0 BV:PRIOR_LOGTAGN BV:PRIOR_MNU BV:PRIOR_NS BV:PRIOR_OMBH2 BV:PRIOR_OMCH2 BV:PRIOR_OMEGAK BV:PRIOR_S8INPUT BV:PRIOR_W BV:PRIOR_WA DATABLOCK DEF RED RUNROOT STORAGEPATH SURVEY
+} 
+#}}}
+
+# Input data {{{ 
+function _inp_data { 
+  #Data inputs (leave blank if none)
+  echo ALLHEAD cosmosis_inputs
+} 
+#}}}
+
+# Output data {{{ 
+function _outputs { 
+  #Data outputs (leave blank if none)
+  outlist='cobaya_inputs'
+  echo ${outlist}
+} 
+#}}}
+
+# Execution command {{{ 
+function _runcommand { 
+  #Command for running the script 
+  echo bash @RUNROOT@/@SCRIPTPATH@/prepare_cobaya.sh
+} 
+#}}}
+
+# Unset Function command {{{ 
+function _unset_functions { 
+  #Remove these functions from the environment
+  unset -f _prompt _description _inp_data _inp_var _abort _outputs _runcommand _unset_functions
+} 
+#}}}
+
+#Additional Functions 
+function translate_to_cobaya {
+  local param=$1
+  local cobaya_param=${param}
+  if [ ${param} == "h0" ]
+  then
+    :
+    # cobaya_param="H0"
+  elif [ ${param} == "n_s" ]
+  then
+    cobaya_param="ns"
+  elif [ ${param} == "omega_k" ]
+  then
+    cobaya_param="omegak"
+  elif [ ${param} == "log_T_AGN" ]
+  then
+    cobaya_param="HMCode_logT_AGN"
+  elif [ ${param} == "Abary" ]
+  then
+    cobaya_param="HMCode_A_baryon"
+  elif [ ${param} == "AIA" ]
+  then
+    cobaya_param="A"
+  fi
+  echo ${cobaya_param}
+}
+
+function write_sampling_params {
+  local param=$1
+  local prefix=$2
+  local indent=1
+  if [ $3 ]
+  then
+    indent=$3
+  fi
+  indent=`seq ${indent} | awk '{printf "  "}'`
+
+  local cobaya_param=$(translate_to_cobaya $1)
+  if [ ! -z "${prefix}" ]
+  then
+    cobaya_param="${prefix}.${cobaya_param}"
+  fi
+
+  local extras=$4
+  
+  #Load the prior variable name {{{
+  local pvar=${param^^}
+  pvar=PRIOR_${pvar//_/}
+  #}}}
+  #get the prior value {{{
+  pprior=`echo ${!pvar}`
+  #}}}
+  #Check the prior is correctly specified {{{
+  nprior=`echo ${pprior} | awk '{print NF}'` 
+  if [ ${nprior} -ne 3 ] && [ ${nprior} -ne 1 ] 
+  then 
+    _message "@RED@ ERROR - prior @DEF@${pvar}@RED@ does not have 3 values! Must be tophat ('lo start hi') or gaussian ('gaussian mean sd')@DEF@\n"
+    _message "@RED@         it is: @DEF@${pprior}\n"
+    exit 1 
+  fi 
+  #}}}
+  if [ ${nprior} == 1 ] 
+  then
+    if [ ! -z "${extras}" ]
+    then
+      echo "${indent}${cobaya_param}:"
+      echo "${indent}  ref: ${pprior}"
+      echo "${indent}  ${extras}"
+    else
+      echo "${indent}${cobaya_param}: ${pprior}"
+    fi
+  else 
+    #Write the prior {{{
+    if [ "${pprior%% *}" == "gaussian" ]
+    then 
+      #Prior is a gaussian {{{
+      parray=(${pprior})
+      #}}}
+      echo "${indent}${cobaya_param}:"
+      echo "${indent}  ref: ${parray[1]}"
+      if [ ! -z "${extras}" ]
+      then
+        echo "${indent}  ${extras}"
+      fi
+      echo "${indent}  prior:"
+      echo "${indent}    dist: norm"
+      echo "${indent}    loc: ${parray[1]}"
+      echo "${indent}    scale: ${parray[2]}"
+      #}}}
+    else
+      parray=(${pprior})
+
+      echo "${indent}${cobaya_param}:"
+      echo "${indent}  ref: ${parray[1]}"
+      if [ ! -z "${extras}" ]
+      then
+        echo "${indent}  ${extras}"
+      fi
+      echo "${indent}  prior:"
+      echo "${indent}    min: ${parray[0]}"
+      echo "${indent}    max: ${parray[2]}"
+    fi 
+    #}}}
+  fi
+}

--- a/scripts/prepare_cobaya.sh
+++ b/scripts/prepare_cobaya.sh
@@ -1,0 +1,144 @@
+#=========================================
+#
+# File Name : prepare_cosmosis.sh
+# Created By : awright
+# Creation Date : 31-03-2023
+# Last Modified : Thu 07 Sep 2023 05:56:22 PM UTC
+#
+#=========================================
+
+#For each of the files in the nz directory 
+inputs="@DB:nz@"
+headfiles="@DB:ALLHEAD@"
+
+NTOMO=`echo @BV:TOMOLIMS@ | awk '{print NF-1}'`
+
+#All possible prior values that might need specification
+PRIOR_AIA="@BV:PRIOR_AIA@"
+PRIOR_ABARY="@BV:PRIOR_ABARY@"
+PRIOR_LOGTAGN="@BV:PRIOR_LOGTAGN@"
+PRIOR_OMCH2="@BV:PRIOR_OMCH2@"
+PRIOR_OMBH2="@BV:PRIOR_OMBH2@"
+PRIOR_H0="@BV:PRIOR_H0@"
+PRIOR_NS="@BV:PRIOR_NS@"
+PRIOR_S8INPUT="@BV:PRIOR_S8INPUT@"
+PRIOR_OMEGAK="@BV:PRIOR_OMEGAK@"
+PRIOR_W="@BV:PRIOR_W@"
+PRIOR_WA="@BV:PRIOR_WA@"
+PRIOR_MNU="@BV:PRIOR_MNU@"
+
+#BOLTZMANN code
+BOLTZMAN=@BV:BOLTZMAN@
+
+#Cobaya .yaml file {{{
+#Create the cobaya_inputs directory
+if [ ! -d @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs ]
+then 
+  mkdir @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs/
+fi 
+#Generate the .yaml file: 
+YAML_FILE_NNAME="@RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@_cobaya.yaml"
+if [ -f ${YAML_FILE_NNAME} ]
+then 
+  _message "  @BLU@Deleting previous yaml file@DEF@"
+  rm ${YAML_FILE_NNAME}
+  _message "@RED@ - Done!@DEF@\n"
+fi 
+
+
+#Prepare the starting items {{{
+cat > ${YAML_FILE_NNAME} <<- EOF
+debug: False
+stop_at_error: True
+timing: True
+output: @RUNROOT@/@STORAGEPATH@/MCMC/output_cobaya/@SURVEY@_@BLINDING@/@BV:BOLTZMAN@/@BV:STATISTIC@/chain/
+sampler:
+  evaluate:
+  # mcmc:
+  #     covmat: proposal_cov.txt
+
+likelihood:
+  cosmosis_cobaya_interface.cosmosis_wrapper.CosmoSISWrapperLikelihood:
+    ini_file: @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cosmosis_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@.ini
+    remove_modules: ["sample_S8", "sigma8toAs", "one_parameter_hmcode", "camb", "cosmopower", "distances"]
+
+    kmax: 20.0
+
+    zmid: 2.0
+    nz_mid: 100
+    zmax: 6.0
+    nz: 150
+
+    zmax_background: 6.0
+    zmin_background: 0.0
+    nz_background: 6000
+  
+    params:
+EOF
+#}}}
+write_sampling_params AIA intrinsic_alignment_parameters 3 >> ${YAML_FILE_NNAME}
+
+#Update the values with the uncorrelated Dz priors {{{
+tomoval_all=`cat @DB:nzbias_uncorr@` 
+#Add the uncorrelated tomographic bin shifts 
+for tomo in `seq ${NTOMO}`
+do
+  tomoval=`echo ${tomoval_all} | awk -v n=${tomo} '{print $n}'`
+  echo "      nofz_shifts.uncorr_bias_${tomo}:" >> ${YAML_FILE_NNAME}
+  echo "        ref: ${tomoval}" >> ${YAML_FILE_NNAME}
+  echo "        prior:" >> ${YAML_FILE_NNAME}
+  echo "          dist: norm" >> ${YAML_FILE_NNAME}
+  echo "          loc: ${tomoval}" >> ${YAML_FILE_NNAME}
+  echo "          scale: 1.0" >> ${YAML_FILE_NNAME}
+done
+#}}}
+
+#Prepare the theory setup and cosmology parameters {{{
+BOLTZMAN="@BV:BOLTZMAN@"
+if [ "${BOLTZMAN^^}" == "CAMB_HM2015" ]
+then
+  CAMB_BOLTZMANN=mead
+elif [ "${BOLTZMAN^^}" == "CAMB_HM2020" ]
+then
+  CAMB_BOLTZMANN=mead2020_feedback
+else
+  _message "@RED@ ERROR - Boltzmann option @DEF@${BOLTZMAN^^}@RED@ not supported by cobaya\n"
+  exit 1 
+fi
+
+cat >> ${YAML_FILE_NNAME} <<- EOF
+theory:
+  camb:
+    extra_args:
+      halofit_version: ${CAMB_BOLTZMANN}
+      neutrino_hierarchy: normal
+
+params:
+EOF
+#}}}
+
+#Add cosmological parameters: {{{
+for param in omch2 ombh2 h0 n_s omega_k w wa mnu 
+do 
+  write_sampling_params ${param} >> ${YAML_FILE_NNAME}
+done
+write_sampling_params s_8_input "" 1 "drop: True" >> ${YAML_FILE_NNAME}
+
+echo "  H0: \"lambda h0: h0*100\"" >> ${YAML_FILE_NNAME}
+echo "  sigma8: \"lambda s_8_input, ombh2, omch2, H0: s_8_input/np.sqrt((ombh2 + omch2)/(H0/100)**2/0.3)\"" >> ${YAML_FILE_NNAME}
+echo "  omegam:" >> ${YAML_FILE_NNAME}
+echo "  As:" >> ${YAML_FILE_NNAME}
+echo "  s8:" >> ${YAML_FILE_NNAME}
+echo "    derived: \"lambda sigma8, omegam: sigma8*np.sqrt(omegam/0.3)\"" >> ${YAML_FILE_NNAME}
+
+if [ "${BOLTZMAN^^}" == "CAMB_HM2020" ]
+then
+  write_sampling_params log_T_AGN >> ${YAML_FILE_NNAME}
+elif [ "${BOLTZMAN^^}" == "CAMB_HM2015" ]
+then
+  write_sampling_params Abary >> ${YAML_FILE_NNAME}
+  echo "  HMCode_eta_baryon: \"lambda HMCode_A_baryon: 0.98 - 0.12*HMCode_A_baryon\"" >> ${YAML_FILE_NNAME}
+fi
+#}}}
+
+

--- a/scripts/prepare_cobaya.sh
+++ b/scripts/prepare_cobaya.sh
@@ -11,134 +11,47 @@
 inputs="@DB:nz@"
 headfiles="@DB:ALLHEAD@"
 
-NTOMO=`echo @BV:TOMOLIMS@ | awk '{print NF-1}'`
 
-#All possible prior values that might need specification
-PRIOR_AIA="@BV:PRIOR_AIA@"
-PRIOR_ABARY="@BV:PRIOR_ABARY@"
-PRIOR_LOGTAGN="@BV:PRIOR_LOGTAGN@"
-PRIOR_OMCH2="@BV:PRIOR_OMCH2@"
-PRIOR_OMBH2="@BV:PRIOR_OMBH2@"
-PRIOR_H0="@BV:PRIOR_H0@"
-PRIOR_NS="@BV:PRIOR_NS@"
-PRIOR_S8INPUT="@BV:PRIOR_S8INPUT@"
-PRIOR_OMEGAK="@BV:PRIOR_OMEGAK@"
-PRIOR_W="@BV:PRIOR_W@"
-PRIOR_WA="@BV:PRIOR_WA@"
-PRIOR_MNU="@BV:PRIOR_MNU@"
-
-#BOLTZMANN code
-BOLTZMAN=@BV:BOLTZMAN@
-
-#Cobaya .yaml file {{{
-#Create the cobaya_inputs directory
-if [ ! -d @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs ]
-then 
-  mkdir @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs/
-fi 
-#Generate the .yaml file: 
-YAML_FILE_NNAME="@RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@_cobaya.yaml"
-if [ -f ${YAML_FILE_NNAME} ]
-then 
-  _message "  @BLU@Deleting previous yaml file@DEF@"
-  rm ${YAML_FILE_NNAME}
-  _message "@RED@ - Done!@DEF@\n"
-fi 
-
-
-#Prepare the starting items {{{
-cat > ${YAML_FILE_NNAME} <<- EOF
-debug: False
-stop_at_error: True
-timing: True
-output: @RUNROOT@/@STORAGEPATH@/MCMC/output_cobaya/@SURVEY@_@BLINDING@/@BV:BOLTZMAN@/@BV:STATISTIC@/chain/
-sampler:
-  evaluate:
-  # mcmc:
-  #     covmat: proposal_cov.txt
-
-likelihood:
-  cosmosis_cobaya_interface.cosmosis_wrapper.CosmoSISWrapperLikelihood:
-    ini_file: @RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cosmosis_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@.ini
-    remove_modules: ["sample_S8", "sigma8toAs", "one_parameter_hmcode", "camb", "cosmopower", "distances"]
-
-    kmax: 20.0
-
-    zmid: 2.0
-    nz_mid: 100
-    zmax: 6.0
-    nz: 150
-
-    zmax_background: 6.0
-    zmin_background: 0.0
-    nz_background: 6000
-  
-    params:
-EOF
-#}}}
-write_sampling_params AIA intrinsic_alignment_parameters 3 >> ${YAML_FILE_NNAME}
-
-#Update the values with the uncorrelated Dz priors {{{
-tomoval_all=`cat @DB:nzbias_uncorr@` 
-#Add the uncorrelated tomographic bin shifts 
-for tomo in `seq ${NTOMO}`
-do
-  tomoval=`echo ${tomoval_all} | awk -v n=${tomo} '{print $n}'`
-  echo "      nofz_shifts.uncorr_bias_${tomo}:" >> ${YAML_FILE_NNAME}
-  echo "        ref: ${tomoval}" >> ${YAML_FILE_NNAME}
-  echo "        prior:" >> ${YAML_FILE_NNAME}
-  echo "          dist: norm" >> ${YAML_FILE_NNAME}
-  echo "          loc: ${tomoval}" >> ${YAML_FILE_NNAME}
-  echo "          scale: 1.0" >> ${YAML_FILE_NNAME}
-done
-#}}}
-
-#Prepare the theory setup and cosmology parameters {{{
+COBAYA_THEORY_CODE="@BV:COBAYATHEORYCODE@"
 BOLTZMAN="@BV:BOLTZMAN@"
-if [ "${BOLTZMAN^^}" == "CAMB_HM2015" ]
+if [ "${COBAYA_THEORY_CODE}" == "cobaya" ]
 then
-  CAMB_BOLTZMANN=mead
-elif [ "${BOLTZMAN^^}" == "CAMB_HM2020" ]
+  if [ "${BOLTZMAN^^}" == "CAMB_HM2015" ]
+  then
+    HALOFIT_VERSION="--halofit_version=mead"
+  elif [ "${BOLTZMAN^^}" == "CAMB_HM2020" ]
+  then
+    HALOFIT_VERSION="--halofit_version=mead2020_feedback"
+  else
+    _message "@RED@ ERROR - Boltzmann option @DEF@${BOLTZMAN^^}@RED@ not supported by cobaya\n"
+    exit 1 
+  fi
+fi
+
+
+COBAYA_SAMPLER=@BV:COBAYASAMPLER@
+if [ "${COBAYA_SAMPLER}" == "mcmc" ]
 then
-  CAMB_BOLTZMANN=mead2020_feedback
+  COBAYA_SAMPLER_COVMAT="--sampler.mcmc.covmat @BV:COBAYASAMPLERCOVMAT@"
 else
-  _message "@RED@ ERROR - Boltzmann option @DEF@${BOLTZMAN^^}@RED@ not supported by cobaya\n"
-  exit 1 
+  COBAYA_SAMPLER_COVMAT=""
 fi
 
-cat >> ${YAML_FILE_NNAME} <<- EOF
-theory:
-  camb:
-    extra_args:
-      halofit_version: ${CAMB_BOLTZMANN}
-      neutrino_hierarchy: normal
+#Generate the .yaml file: 
+YAML_FILE_NAME="@RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cobaya_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@_cobaya_@BV:COBAYASAMPLER@_@BV:COBAYATHEORYCODE@_theory.yaml"
 
-params:
-EOF
+COSMOSIS_PIPELINE_FILE="@RUNROOT@/@STORAGEPATH@/@DATABLOCK@/cosmosis_inputs/@SURVEY@_CosmoPipe_constructed_@BV:STATISTIC@.ini"
+
+OUTPUT_FOLDER="@RUNROOT@/@STORAGEPATH@/MCMC/output_cobaya/@SURVEY@_@BLINDING@/@BV:BOLTZMAN@/@BV:STATISTIC@/@BV:COBAYASAMPLER@_@BV:COBAYATHEORYCODE@_theory/"
+
+#TODO? Read cosmosis file path from somewhere
+#Run the cobaya preparation script {{{
+_message " > @BLU@Constructing the cobaya configuration for @RED@${COSMOSIS_PIPELINE_FILE}@DEF@"
+@PYTHON3BIN@ -m cosmosis_cobaya_interface.prepare_config \
+  --pipeline-file ${COSMOSIS_PIPELINE_FILE} \
+  --boltzmann-code ${COBAYA_THEORY_CODE} \
+  ${HALOFIT_VERSION} --sampler ${COBAYA_SAMPLER} ${COBAYA_SAMPLER_COVMAT} \
+  --output-yaml-file ${YAML_FILE_NAME} \
+  --cobaya-output-path ${OUTPUT_FOLDER} 2>&1 
+_message " - @RED@Done!@DEF@\n"
 #}}}
-
-#Add cosmological parameters: {{{
-for param in omch2 ombh2 h0 n_s omega_k w wa mnu 
-do 
-  write_sampling_params ${param} >> ${YAML_FILE_NNAME}
-done
-write_sampling_params s_8_input "" 1 "drop: True" >> ${YAML_FILE_NNAME}
-
-echo "  H0: \"lambda h0: h0*100\"" >> ${YAML_FILE_NNAME}
-echo "  sigma8: \"lambda s_8_input, ombh2, omch2, H0: s_8_input/np.sqrt((ombh2 + omch2)/(H0/100)**2/0.3)\"" >> ${YAML_FILE_NNAME}
-echo "  omegam:" >> ${YAML_FILE_NNAME}
-echo "  As:" >> ${YAML_FILE_NNAME}
-echo "  s8:" >> ${YAML_FILE_NNAME}
-echo "    derived: \"lambda sigma8, omegam: sigma8*np.sqrt(omegam/0.3)\"" >> ${YAML_FILE_NNAME}
-
-if [ "${BOLTZMAN^^}" == "CAMB_HM2020" ]
-then
-  write_sampling_params log_T_AGN >> ${YAML_FILE_NNAME}
-elif [ "${BOLTZMAN^^}" == "CAMB_HM2015" ]
-then
-  write_sampling_params Abary >> ${YAML_FILE_NNAME}
-  echo "  HMCode_eta_baryon: \"lambda HMCode_A_baryon: 0.98 - 0.12*HMCode_A_baryon\"" >> ${YAML_FILE_NNAME}
-fi
-#}}}
-
-


### PR DESCRIPTION
The interface reads the outputs from the `cosmosis_constructor` step, specifically the final `.ini` file and the `values` and `priors` files.

Options:
- `COBAYATHEORYCODE`: either `cosmosis`, in which case the CosmoSIS pipeline is taken as-is, or `cobaya`, in which case the Boltzmann modules are removed from the CosmoSIS pipeline and the cobaya Boltzmann codes are used.
- `COBAYASAMPLER`: either `evalute`, which is similar to the CosmoSIS `test` sampler, or `mcmc`
- `COBAYASAMPLERCOVMAT`: When using the cobaya Metropolis-Hastings MCMC algorithm, a good proposal is necessary. The sampler can learn the parameter covariance but giving it a good starting point helps.

Dependencies:
- cobaya
- https://github.com/tilmantroester/cobaya_cosmosis_interface (`pip`-installable, not on PyPI yet)

I've not added or modified the `run_chain` step yet, as the stuff there is somewhat hardware-specific. Things to note are that the cobaya MCMC uses MPI to run independent chains in parallel, which does not speed up convergence. Using OpenMP to speed up the individual chains helps but hits diminishing returns at some point because other modules (e.g. `cosebis`) don't take advantage of OpenMP.

![cobaya_vs_nautilus](https://github.com/user-attachments/assets/ea2ac756-4e8b-477e-bee5-89cd5100b4b2)
